### PR TITLE
Use Python 3.8 in Dockerfile to match development environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.8
 
 WORKDIR /src
 


### PR DESCRIPTION
Or use Python 3.11 in development as well (We should update the README then)

But we all know Python 3.11 is not very stable yet when it comes to dependencies  :grinning: 